### PR TITLE
Prevent duplicate reason messages

### DIFF
--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -635,8 +635,18 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
   await saveMessage(userMessage);
 
   if (bookingFlow.step === 'reason') {
-    setBookingFlow({ ...bookingFlow, reason: userMessage.message, step: 'dentist' });
-    addBotMessage(`Got it! You're experiencing: **${userMessage.message}**.`);
+    if (!bookingFlow.reason) {
+      setBookingFlow({
+        ...bookingFlow,
+        reason: userMessage.message,
+        step: 'dentist'
+      });
+      addBotMessage(`Got it! You're experiencing: **${userMessage.message}**.`);
+    } else {
+      // Avoid repeating the confirmation if the reason was already provided
+      setBookingFlow({ ...bookingFlow, step: 'dentist' });
+    }
+
     await loadDentistsForBooking(false);
     setIsLoading(false);
     return;


### PR DESCRIPTION
## Summary
- avoid repeating the "Got it!" message when the patient repeats their symptom

## Testing
- `npm run lint` *(fails: 54 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_688c5c874bf4832c95590f7da679acb0