### PR TITLE
Troubleshoot csv import failure

### DIFF
--- a/supabase/functions/process-csv-import/index.ts
+++ b/supabase/functions/process-csv-import/index.ts
@@ -3,7 +3,7 @@ import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-user-id',
   'Access-Control-Allow-Methods': 'GET, POST, OPTIONS, PUT, DELETE',
 };
 

--- a/supabase/functions/send-invitation-email/index.ts
+++ b/supabase/functions/send-invitation-email/index.ts
@@ -11,7 +11,7 @@ interface InvitationEmailRequest {
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
-  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type, x-user-id',
 };
 
 serve(async (req) => {


### PR DESCRIPTION
Add `x-user-id` to CORS allowed headers in edge functions to fix CSV import preflight failures.

The client was sending a custom `x-user-id` header during CSV import, but the Supabase edge functions were not configured to allow this header in their CORS policy, causing preflight requests to fail.

---
<a href="https://cursor.com/background-agent?bcId=bc-500fd6ce-0f06-4600-85f2-f3be30976ed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-500fd6ce-0f06-4600-85f2-f3be30976ed6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

