### PR TITLE
Validate single react child element

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -58,7 +58,18 @@ export interface ButtonProps
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, loading, icon, rightIcon, children, disabled, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
-    
+
+    const content = (
+      <>
+        {loading && (
+          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
+        )}
+        {!loading && icon && icon}
+        {children}
+        {!loading && rightIcon && rightIcon}
+      </>
+    )
+
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
@@ -66,12 +77,7 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         disabled={disabled || loading}
         {...props}
       >
-        {loading && (
-          <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-current" />
-        )}
-        {!loading && icon && icon}
-        {children}
-        {!loading && rightIcon && rightIcon}
+        {asChild ? children : content}
       </Comp>
     )
   }


### PR DESCRIPTION
Fix 'React.Children.only' error by ensuring `Button` renders a single child when `asChild` is true.

---
<a href="https://cursor.com/background-agent?bcId=bc-464c0f20-290f-4569-b17e-71d2258498ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-464c0f20-290f-4569-b17e-71d2258498ca">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

