### PR TITLE
Fix account confirmation access token error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { supabase } from "@/integrations/supabase/client";
 import { User, Session } from "@supabase/supabase-js";
 import { SeoManager } from "./lib/seo";
 import { LazyLoadingWrapper } from "./components/optimized/LazyLoadingWrapper";
+import AuthCallbackHandler from "./components/AuthCallbackHandler";
 
 const Invite = lazy(() => import("./pages/Invite"));
 
@@ -119,6 +120,7 @@ const App = () => (
         disableTransitionOnChange={false}
       >
         <LanguageProvider>
+            <AuthCallbackHandler />
             <TooltipProvider>
               <Sonner />
               <PWAInstallPrompt />

--- a/src/components/AuthCallbackHandler.tsx
+++ b/src/components/AuthCallbackHandler.tsx
@@ -1,0 +1,70 @@
+import { useEffect } from "react";
+import { supabase } from "@/integrations/supabase/client";
+
+/**
+ * Processes Supabase auth callback parameters then cleans the URL.
+ * - Handles PKCE code exchange (?code=...)
+ * - Handles implicit hash fragments (#access_token=...)
+ * - Removes query/hash from the URL after processing
+ */
+export const AuthCallbackHandler = () => {
+  useEffect(() => {
+    const processAuthCallback = async () => {
+      const currentUrl = new URL(window.location.href);
+      const { search, hash } = currentUrl;
+
+      const hasPkceCode = currentUrl.searchParams.has("code");
+      const hasImplicitHash =
+        hash.includes("access_token") ||
+        hash.includes("refresh_token") ||
+        hash.includes("provider_token") ||
+        hash.includes("error");
+
+      const cleanupUrl = (removeAllParams: boolean) => {
+        const cleaned = removeAllParams
+          ? `${currentUrl.origin}${currentUrl.pathname}`
+          : `${currentUrl.origin}${currentUrl.pathname}${currentUrl.search}`;
+        window.history.replaceState({}, document.title, cleaned);
+      };
+
+      try {
+        if (hasPkceCode) {
+          // PKCE callback: exchange code for a session
+          await supabase.auth.exchangeCodeForSession(window.location.href);
+          // Remove the code and other params from the URL entirely
+          cleanupUrl(true);
+          return;
+        }
+
+        if (hasImplicitHash) {
+          // Parse tokens from the hash and set the session explicitly (robust across environments)
+          const params = new URLSearchParams(hash.replace(/^#/, ""));
+          const access_token = params.get("access_token") || undefined;
+          const refresh_token = params.get("refresh_token") || undefined;
+
+          if (access_token && refresh_token) {
+            await supabase.auth.setSession({ access_token, refresh_token });
+          } else {
+            // Fallback: trigger internal detection if available
+            await supabase.auth.getSession();
+          }
+
+          // Remove the hash portion from the URL (keep any non-auth search params)
+          cleanupUrl(false);
+        }
+      } catch (error) {
+        console.error("Auth callback processing failed:", error);
+        // Attempt to clean up even on failure to avoid exposing tokens in the URL
+        if (hasImplicitHash || hasPkceCode) {
+          cleanupUrl(hasPkceCode);
+        }
+      }
+    };
+
+    processAuthCallback();
+  }, []);
+
+  return null;
+};
+
+export default AuthCallbackHandler;

--- a/src/integrations/supabase/client.ts
+++ b/src/integrations/supabase/client.ts
@@ -14,6 +14,7 @@ export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_PUBLISHABL
     storage: localStorage,
     persistSession: true,
     autoRefreshToken: true,
+    detectSessionInUrl: true,
   }
 });
 


### PR DESCRIPTION
Cleans up Supabase authentication redirect URLs to remove `access_token` hashes and PKCE codes.

This change ensures that after a user signs in or confirms their email via Supabase, the URL no longer displays sensitive tokens or temporary codes, improving security and user experience by presenting a clean URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-1693b41b-9491-4afb-81eb-fd10603e3aa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1693b41b-9491-4afb-81eb-fd10603e3aa3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

