### PR TITLE
Debug account claim error

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { User, Session } from "@supabase/supabase-js";
 import { SeoManager } from "./lib/seo";
 import { LazyLoadingWrapper } from "./components/optimized/LazyLoadingWrapper";
 import AuthCallbackHandler from "./components/AuthCallbackHandler";
+import { ModernLoadingSpinner } from "@/components/enhanced/ModernLoadingSpinner";
 
 const Invite = lazy(() => import("./pages/Invite"));
 
@@ -127,6 +128,7 @@ const App = () => (
               <ProfileCompletionDialog />
               <BrowserRouter>
                 <SeoManager />
+              <Suspense fallback={<ModernLoadingSpinner variant="overlay" message="Loading..." /> }>
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/dashboard" element={<Dashboard />} />
@@ -149,6 +151,7 @@ const App = () => (
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
                 <Route path="*" element={<NotFound />} />
               </Routes>
+              </Suspense>
             </BrowserRouter>
           </TooltipProvider>
         </LanguageProvider>


### PR DESCRIPTION
Add a Suspense fallback to the main React Router Routes to resolve React error #426 during lazy loading.

The "Minified React error #426" occurred when navigating to lazy-loaded routes, specifically the Account Claim flow, because there was no Suspense boundary to handle the asynchronous loading of these components. Wrapping the `<Routes>` component with `<Suspense>` provides a fallback UI while the lazy components are being loaded, preventing the error.

---
<a href="https://cursor.com/background-agent?bcId=bc-6eba5e48-b0bb-47ef-aa61-1911c0e8f067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6eba5e48-b0bb-47ef-aa61-1911c0e8f067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

