### PR TITLE
Update account claim to prompt for password

### DIFF
--- a/src/pages/Claim.tsx
+++ b/src/pages/Claim.tsx
@@ -103,13 +103,9 @@ const Claim = () => {
         }
       }
 
-      if (proceedPassword) {
-        setStep("password");
-        await minDelayPromise;
-        return;
-      }
-
-      setStep("neutral");
+      // Always allow proceeding to password creation. The backend will
+      // validate claimability and respond generically if not allowed.
+      setStep("password");
       await minDelayPromise;
       return;
     } catch (_err) {


### PR DESCRIPTION
Always proceed to the password creation step in the claim flow.

The previous flow showed a neutral message ("If an account exists for this email, we’ll help you sign in.") before potentially moving to password creation. This change ensures users are always prompted to create a password, aligning with the user's expectation, while backend validation still prevents unauthorized claims.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8b7bb8c-d9fd-4067-b6cc-d5cb45d24090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8b7bb8c-d9fd-4067-b6cc-d5cb45d24090">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

