### PR TITLE
Add sidebar collapse button

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -53,6 +53,7 @@ import {
   Bell,
   ChevronDown,
   Home,
+  PanelLeft,
 } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -92,6 +93,7 @@ function TopBar() {
   const [userId, setUserId] = useState<string | null>(null);
   const { setTheme, theme } = useTheme();
   const { language, setLanguage, t } = useLanguage();
+  const { state, toggleSidebar } = useSidebar();
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data }) => setUserId(data.session?.user?.id ?? null));
@@ -100,7 +102,18 @@ function TopBar() {
   return (
     <div className="sticky top-0 z-40 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
       <div className="flex items-center gap-2 px-3 md:px-4 py-2">
-        <SidebarTrigger />
+        <SidebarTrigger className="md:hidden" />
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={toggleSidebar}
+          className="hidden md:inline-flex gap-2"
+          aria-label={state === 'expanded' ? 'Collapse sidebar' : 'Expand sidebar'}
+          title={state === 'expanded' ? 'Collapse sidebar' : 'Expand sidebar'}
+        >
+          <PanelLeft className="h-4 w-4" />
+          <span>{state === 'expanded' ? 'Collapse' : 'Expand'}</span>
+        </Button>
         <div className="flex items-center gap-2 text-muted-foreground">
           <Home className="h-4 w-4" />
           <Separator orientation="vertical" className="h-4" />

--- a/src/components/patient/PatientPortalNav.tsx
+++ b/src/components/patient/PatientPortalNav.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Outlet, useLocation, useNavigate } from "react-router-dom";
-import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger } from "@/components/ui/sidebar";
+import { Sidebar, SidebarContent, SidebarFooter, SidebarGroup, SidebarGroupAction, SidebarGroupContent, SidebarGroupLabel, SidebarHeader, SidebarMenu, SidebarMenuBadge, SidebarMenuButton, SidebarMenuItem, SidebarProvider, SidebarRail, SidebarSeparator, SidebarTrigger, useSidebar } from "@/components/ui/sidebar";
 import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useLanguage } from "@/hooks/useLanguage";
-import { Home, Calendar, Pill, FileText, CreditCard, Folder, User, IdCard, Shield, HelpCircle, ChevronDown, MoreHorizontal } from "lucide-react";
+import { Home, Calendar, Pill, FileText, CreditCard, Folder, User, IdCard, Shield, HelpCircle, ChevronDown, MoreHorizontal, PanelLeft } from "lucide-react";
 import { usePatientBadgeCounts } from "@/hooks/usePatientBadges";
 import { cn } from "@/lib/utils";
 import { emitAnalyticsEvent } from "@/lib/analyticsEvents";
@@ -46,6 +46,7 @@ export function PatientPortalNav({ children }: { children: React.ReactNode }) {
   const { t } = useLanguage();
   const location = useLocation();
   const navigate = useNavigate();
+  const { state, toggleSidebar } = useSidebar();
   const { counts } = usePatientBadgeCounts();
   const [openGroupId, setOpenGroupId] = useState<string | null>(() => localStorage.getItem(STORAGE_KEYS.lastGroup));
   const [moreOpen, setMoreOpen] = useState(false);
@@ -287,7 +288,20 @@ export function PatientPortalNav({ children }: { children: React.ReactNode }) {
         </Sidebar>
         <div className="flex-1">
           <div className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b px-3 py-2 flex items-center justify-between">
-            <SidebarTrigger />
+            <div className="flex items-center gap-2">
+              <SidebarTrigger className="md:hidden" />
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={toggleSidebar}
+                className="hidden md:inline-flex gap-2"
+                aria-label={state === 'expanded' ? 'Collapse sidebar' : 'Expand sidebar'}
+                title={state === 'expanded' ? 'Collapse sidebar' : 'Expand sidebar'}
+              >
+                <PanelLeft className="h-4 w-4" />
+                <span>{state === 'expanded' ? 'Collapse' : 'Expand'}</span>
+              </Button>
+            </div>
             {/* Primary CTA per spec: on Home header show Book appointment, CTA placement handled in page components */}
           </div>
           <div className="p-3 md:p-4">{children ?? <Outlet />}</div>


### PR DESCRIPTION
Add a visible 'Collapse/Expand' button to the sidebar in the dentist dashboard and patient portal headers to improve discoverability for laptop users.

---
<a href="https://cursor.com/background-agent?bcId=bc-78bbba04-55c0-47ee-904a-2cd9084e54a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78bbba04-55c0-47ee-904a-2cd9084e54a8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

